### PR TITLE
Multi node

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Running
         -a, --access-log LOGFILE         Access log file
         -d, --detached                   Run as a daemon.
         -P, --pidfile PIDFILE            Location to write pid file.
+        --name NAME                      Erlang process name.
+        --sname SNAME                    Erlang short process name.
 
     Commands:
       <none>                Start an Ernie server.

--- a/bin/ernie
+++ b/bin/ernie
@@ -64,8 +64,12 @@ OptionParser.new do |opts|
     options[:detached] = true
   end
 
-  opts.on("--name NAME", "Proccess name") do |x|
+  opts.on("--name NAME", "Erlang proccess name") do |x|
     options[:name] = x
+  end
+
+  opts.on("--sname NAME", "Erlang short proccess name") do |x|
+    options[:sname] = x
   end
 
   opts.on("-P", "--pidfile PIDFILE", "Location to write pid file.") do |x|
@@ -100,9 +104,11 @@ else
   detached = options[:detached] ? '-detached' : ''
   access_log = options[:access_log] ? "-ernie_server_app access_log '\"#{options[:access_log]}\"'" : ''
   name = options[:name] ? "-name #{options[:name]}" : ''
+  sname = options[:sname] ? "-sname #{options[:sname]}" : ''
 
   cmd = %Q{erl -boot start_sasl \
                #{name} \
+               #{sname} \
                #{detached} \
                +Bc \
                +K true \

--- a/bin/ernie
+++ b/bin/ernie
@@ -64,6 +64,10 @@ OptionParser.new do |opts|
     options[:detached] = true
   end
 
+  opts.on("--name NAME", "Proccess name") do |x|
+    options[:name] = x
+  end
+
   opts.on("-P", "--pidfile PIDFILE", "Location to write pid file.") do |x|
     options[:pidfile] = x
   end
@@ -95,8 +99,10 @@ else
   pidfile = options[:pidfile] ? "-ernie_server_app pidfile \"'#{options[:pidfile]}'\"" : ''
   detached = options[:detached] ? '-detached' : ''
   access_log = options[:access_log] ? "-ernie_server_app access_log '\"#{options[:access_log]}\"'" : ''
+  name = options[:name] ? "-name #{options[:name]}" : ''
 
   cmd = %Q{erl -boot start_sasl \
+               #{name} \
                #{detached} \
                +Bc \
                +K true \
@@ -109,5 +115,6 @@ else
                -ernie_server_app log_level #{log_level} \
                -run ernie_server_app boot}.squeeze(' ')
   puts cmd
+  STDOUT.flush
   exec(cmd)
 end

--- a/elib/ernie_access_logger.erl
+++ b/elib/ernie_access_logger.erl
@@ -18,19 +18,19 @@
 %%====================================================================
 
 start_link(Args) ->
-  gen_server:start_link({global, ?MODULE}, ?MODULE, Args, []).
+  gen_server:start_link({global, {node(),?MODULE}}, ?MODULE, Args, []).
 
 start(Args) ->
-  gen_server:start({global, ?MODULE}, ?MODULE, Args, []).
+  gen_server:start({global, {node(),?MODULE}}, ?MODULE, Args, []).
 
 acc(Request) ->
-  gen_server:cast({global, ?MODULE}, {acc, Request}).
+  gen_server:cast({global, {node(),?MODULE}}, {acc, Request}).
 
 err(Request, Msg, Args) ->
-  gen_server:cast({global, ?MODULE}, {err, Request, Msg, Args}).
+  gen_server:cast({global, {node(),?MODULE}}, {err, Request, Msg, Args}).
 
 reopen() ->
-  gen_server:cast({global, ?MODULE}, reopen).
+  gen_server:cast({global, {node(),?MODULE}}, reopen).
 
 %%====================================================================
 %% gen_server callbacks

--- a/elib/ernie_access_logger.erl
+++ b/elib/ernie_access_logger.erl
@@ -18,19 +18,19 @@
 %%====================================================================
 
 start_link(Args) ->
-  gen_server:start_link({global, {node(),?MODULE}}, ?MODULE, Args, []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, Args, []).
 
 start(Args) ->
-  gen_server:start({global, {node(),?MODULE}}, ?MODULE, Args, []).
+  gen_server:start({global, ?MODULE}, ?MODULE, Args, []).
 
 acc(Request) ->
-  gen_server:cast({global, {node(),?MODULE}}, {acc, Request}).
+  gen_server:cast(?MODULE, {acc, Request}).
 
 err(Request, Msg, Args) ->
-  gen_server:cast({global, {node(),?MODULE}}, {err, Request, Msg, Args}).
+  gen_server:cast(?MODULE, {err, Request, Msg, Args}).
 
 reopen() ->
-  gen_server:cast({global, {node(),?MODULE}}, reopen).
+  gen_server:cast(?MODULE, reopen).
 
 %%====================================================================
 %% gen_server callbacks

--- a/elib/ernie_server.erl
+++ b/elib/ernie_server.erl
@@ -14,19 +14,19 @@
 %%====================================================================
 
 start_link(Args) ->
-  gen_server:start_link({global, {node(),?MODULE}}, ?MODULE, Args, []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, Args, []).
 
 start(Args) ->
-  gen_server:start({global, {node(),?MODULE}}, ?MODULE, Args, []).
+  gen_server:start({local, ?MODULE}, ?MODULE, Args, []).
 
 process(Sock) ->
-  gen_server:cast({global, {node(),?MODULE}}, {process, Sock}).
+  gen_server:cast(?MODULE, {process, Sock}).
 
 kick() ->
-  gen_server:cast({global, {node(),?MODULE}}, kick).
+  gen_server:cast(?MODULE, kick).
 
 fin() ->
-  gen_server:cast({global, {node(),?MODULE}}, fin).
+  gen_server:cast(?MODULE, fin).
 
 %%====================================================================
 %% gen_server callbacks

--- a/elib/ernie_server.erl
+++ b/elib/ernie_server.erl
@@ -14,19 +14,19 @@
 %%====================================================================
 
 start_link(Args) ->
-  gen_server:start_link({global, ?MODULE}, ?MODULE, Args, []).
+  gen_server:start_link({global, {node(),?MODULE}}, ?MODULE, Args, []).
 
 start(Args) ->
-  gen_server:start({global, ?MODULE}, ?MODULE, Args, []).
+  gen_server:start({global, {node(),?MODULE}}, ?MODULE, Args, []).
 
 process(Sock) ->
-  gen_server:cast({global, ?MODULE}, {process, Sock}).
+  gen_server:cast({global, {node(),?MODULE}}, {process, Sock}).
 
 kick() ->
-  gen_server:cast({global, ?MODULE}, kick).
+  gen_server:cast({global, {node(),?MODULE}}, kick).
 
 fin() ->
-  gen_server:cast({global, ?MODULE}, fin).
+  gen_server:cast({global, {node(),?MODULE}}, fin).
 
 %%====================================================================
 %% gen_server callbacks

--- a/elib/logger.erl
+++ b/elib/logger.erl
@@ -15,28 +15,28 @@
 %%====================================================================
 
 start_link(Args) ->
-  gen_server:start_link({global, ?MODULE}, ?MODULE, Args, []).
+  gen_server:start_link({global, {node(),?MODULE}}, ?MODULE, Args, []).
 
 start(Args) ->
-  gen_server:start({global, ?MODULE}, ?MODULE, Args, []).
+  gen_server:start({global, {node(),?MODULE}}, ?MODULE, Args, []).
 
 set_log_level(Level) ->
-  gen_server:call({global, ?MODULE}, {set_log_level, Level}).
+  gen_server:call({global, {node(),?MODULE}}, {set_log_level, Level}).
 
 debug(Msg, Args) ->
-  gen_server:cast({global, ?MODULE}, {debug, Msg, Args}).
+  gen_server:cast({global, {node(),?MODULE}}, {debug, Msg, Args}).
 
 info(Msg, Args) ->
-  gen_server:cast({global, ?MODULE}, {info, Msg, Args}).
+  gen_server:cast({global, {node(),?MODULE}}, {info, Msg, Args}).
 
 warn(Msg, Args) ->
-  gen_server:cast({global, ?MODULE}, {warn, Msg, Args}).
+  gen_server:cast({global, {node(),?MODULE}}, {warn, Msg, Args}).
 
 error(Msg, Args) ->
-  gen_server:cast({global, ?MODULE}, {error, Msg, Args}).
+  gen_server:cast({global, {node(),?MODULE}}, {error, Msg, Args}).
 
 fatal(Msg, Args) ->
-  gen_server:cast({global, ?MODULE}, {fatal, Msg, Args}).
+  gen_server:cast({global, {node(),?MODULE}}, {fatal, Msg, Args}).
 
 %%====================================================================
 %% gen_server callbacks

--- a/elib/logger.erl
+++ b/elib/logger.erl
@@ -15,28 +15,28 @@
 %%====================================================================
 
 start_link(Args) ->
-  gen_server:start_link({global, {node(),?MODULE}}, ?MODULE, Args, []).
+  gen_server:start_link({local, ?MODULE}, ?MODULE, Args, []).
 
 start(Args) ->
-  gen_server:start({global, {node(),?MODULE}}, ?MODULE, Args, []).
+  gen_server:start({local, ?MODULE}, ?MODULE, Args, []).
 
 set_log_level(Level) ->
-  gen_server:call({global, {node(),?MODULE}}, {set_log_level, Level}).
+  gen_server:call(?MODULE, {set_log_level, Level}).
 
 debug(Msg, Args) ->
-  gen_server:cast({global, {node(),?MODULE}}, {debug, Msg, Args}).
+  gen_server:cast(?MODULE, {debug, Msg, Args}).
 
 info(Msg, Args) ->
-  gen_server:cast({global, {node(),?MODULE}}, {info, Msg, Args}).
+  gen_server:cast(?MODULE, {info, Msg, Args}).
 
 warn(Msg, Args) ->
-  gen_server:cast({global, {node(),?MODULE}}, {warn, Msg, Args}).
+  gen_server:cast(?MODULE, {warn, Msg, Args}).
 
 error(Msg, Args) ->
-  gen_server:cast({global, {node(),?MODULE}}, {error, Msg, Args}).
+  gen_server:cast(?MODULE, {error, Msg, Args}).
 
 fatal(Msg, Args) ->
-  gen_server:cast({global, {node(),?MODULE}}, {fatal, Msg, Args}).
+  gen_server:cast(?MODULE, {fatal, Msg, Args}).
 
 %%====================================================================
 %% gen_server callbacks

--- a/test/ernie_server_test.rb
+++ b/test/ernie_server_test.rb
@@ -58,6 +58,8 @@ class ErnieServerTest < Test::Unit::TestCase
           fail "Expected a BERTRPC::ServerError"
         rescue BERTRPC::ServerError => e
           assert_equal "No such module 'failboat'", e.message
+        else
+          assert false, 'failed to raise on missing module'
         end
       end
 
@@ -67,6 +69,17 @@ class ErnieServerTest < Test::Unit::TestCase
           fail "Expected a BERTRPC::ServerError"
         rescue BERTRPC::ServerError => e
           assert_equal "No such function 'ext:mcfail'", e.message
+        else
+          assert false, 'failed to raise on missing function'
+        end
+
+        begin
+          svc.call.intTest.mcfail(:fail)
+          fail "Expected a BERTRPC::ServerError"
+        rescue BERTRPC::ServerError => e
+          assert_equal "No such function 'intTest:mcfail'", e.message
+        else
+          assert false, 'failed to raise on missing function'
         end
       end
     end

--- a/test/ernie_server_test.rb
+++ b/test/ernie_server_test.rb
@@ -3,6 +3,24 @@ require File.dirname(__FILE__) + '/helper'
 PORT = 27118
 
 class ErnieServerTest < Test::Unit::TestCase
+
+  # global setup
+  def setup
+    @servers ||= []
+    Dir.chdir(ERNIE_ROOT)
+    `erlc #{ERNIE_ROOT}/test/sample/intTest.erl`
+    Signal.trap("INT") do
+      puts "Shutting Down"
+      shutdown_servers
+      teardown
+      exit
+    end
+  end
+  
+  def teardown
+    `rm intTest.beam`
+  end
+
   context "An Ernie Server" do
     setup do
       start_server
@@ -10,33 +28,33 @@ class ErnieServerTest < Test::Unit::TestCase
 
     context "call" do
       should "handle zeronary" do
-        assert_equal :foo, @svc.call.ext.zeronary
-        assert_equal :foo, @svc.call.intTest.zeronary
+        assert_equal :foo, svc.call.ext.zeronary
+        assert_equal :foo, svc.call.intTest.zeronary
       end
 
       should "handle unary" do
-        assert_equal 5, @svc.call.ext.unary(5)
-        assert_equal 5, @svc.call.intTest.unary(5)
+        assert_equal 5, svc.call.ext.unary(5)
+        assert_equal 5, svc.call.intTest.unary(5)
       end
 
       should "handle binary" do
-        assert_equal 7, @svc.call.ext.binary(5, 2)
-        assert_equal 7, @svc.call.intTest.binary(5, 2)
+        assert_equal 7, svc.call.ext.binary(5, 2)
+        assert_equal 7, svc.call.intTest.binary(5, 2)
       end
 
       should "handle ternary" do
-        assert_equal 10, @svc.call.ext.ternary(5, 2, 3)
-        assert_equal 10, @svc.call.intTest.ternary(5, 2, 3)
+        assert_equal 10, svc.call.ext.ternary(5, 2, 3)
+        assert_equal 10, svc.call.intTest.ternary(5, 2, 3)
       end
 
       should "handle massive binaries" do
-        assert_equal 8 * 1024 * 1024, @svc.call.ext.big(8 * 1024 * 1024).size
-        assert_equal 8 * 1024 * 1024, @svc.call.intTest.big(8 * 1024 * 1024).size
+        assert_equal 8 * 1024 * 1024, svc.call.ext.big(8 * 1024 * 1024).size
+        assert_equal 8 * 1024 * 1024, svc.call.intTest.big(8 * 1024 * 1024).size
       end
 
       should "get an error on missing module" do
         begin
-          @svc.call.failboat.mcfail(:fail)
+          svc.call.failboat.mcfail(:fail)
           fail "Expected a BERTRPC::ServerError"
         rescue BERTRPC::ServerError => e
           assert_equal "No such module 'failboat'", e.message
@@ -45,7 +63,7 @@ class ErnieServerTest < Test::Unit::TestCase
 
       should "get an error on missing function" do
         begin
-          @svc.call.ext.mcfail(:fail)
+          svc.call.ext.mcfail(:fail)
           fail "Expected a BERTRPC::ServerError"
         rescue BERTRPC::ServerError => e
           assert_equal "No such function 'ext:mcfail'", e.message
@@ -56,9 +74,9 @@ class ErnieServerTest < Test::Unit::TestCase
     context "cast" do
       should "be received and return immediately" do
         t0 = Time.now
-        assert_equal nil, @svc.cast.ext.set_state(7)
+        assert_equal nil, svc.cast.ext.set_state(7)
         assert Time.now - t0 < 1
-        assert_equal 7, @svc.call.ext.get_state
+        assert_equal 7, svc.call.ext.get_state
       end
     end
 
@@ -67,36 +85,95 @@ class ErnieServerTest < Test::Unit::TestCase
     end
   end
   
-  protected
-  
-  def start_server
-    Dir.chdir(ERNIE_ROOT)
-    `erlc #{ERNIE_ROOT}/test/sample/intTest.erl`
-    `#{ERNIE_ROOT}/bin/ernie -c #{ERNIE_ROOT}/test/sample/sample.cfg \
-                            -P /tmp/ernie.pid \
-                            -p #{PORT} \
-                            -d`
-    Signal.trap("INT") do
-      puts "Shutting Down"
-      shutdown_server
-      exit
+  context "Two Ernie Servers" do
+    setup do
+      start_servers(2)
     end
     
-     @svc = BERTRPC::Service.new('localhost', PORT)
-     loop do
-       begin
-         @svc.call.ext.zeronary
-         break
-       rescue Object => e
-         sleep 0.1
-       end
-     end
+    context "call" do
+
+      should "handle zeronary" do
+        @servers.each do |svc|
+          assert_equal :foo, svc.call.ext.zeronary
+          assert_equal :foo, svc.call.intTest.zeronary
+        end
+      end
+
+      should "handle unary" do
+        @servers.each do |svc|
+          assert_equal 5, svc.call.ext.unary(5)
+          assert_equal 5, svc.call.intTest.unary(5)
+        end
+      end
+
+      should "handle binary" do
+        @servers.each do |svc|
+          assert_equal 7, svc.call.ext.binary(5, 2)
+          assert_equal 7, svc.call.intTest.binary(5, 2)
+        end
+      end
+
+      should "handle ternary" do
+        @servers.each do |svc|
+          assert_equal 10, svc.call.ext.ternary(5, 2, 3)
+          assert_equal 10, svc.call.intTest.ternary(5, 2, 3)
+        end
+      end
+
+      should "handle massive binaries" do
+        @servers.each do |svc|
+          assert_equal 8 * 1024 * 1024, svc.call.ext.big(8 * 1024 * 1024).size
+          assert_equal 8 * 1024 * 1024, svc.call.intTest.big(8 * 1024 * 1024).size
+        end
+      end
+
+    end
+
+    teardown do
+      shutdown_servers(2)
+    end
+  end
+  
+  protected
+  
+  def svc
+    @servers[rand(@servers.size-1)]
+  end
+  
+  def start_server
+    start_servers(1)
   end
   
   def shutdown_server
-    pid = File.read('/tmp/ernie.pid')
-    `kill -9 #{pid}`
-    `rm intTest.beam`
+    shutdown_servers(1)
+  end
+  
+  def start_servers(n = 1)
+    n.times do
+      `#{ERNIE_ROOT}/bin/ernie -c #{ERNIE_ROOT}/test/sample/sample.cfg \
+                              -P /tmp/ernie#{@servers.size}.pid \
+                              -p #{PORT + @servers.size} \
+                              -d`
+    
+      @servers << BERTRPC::Service.new('localhost', PORT + @servers.size)
+      loop do
+        begin
+          @servers.last.call.ext.zeronary
+          break
+        rescue Object => e
+          sleep 0.1
+        end
+      end
+    end
+  end
+  
+  def shutdown_servers(n = nil)
+    start = @servers.size - 1
+    last = start - (n || start)
+    (start).downto(last >= 0 ? last : 0) do |i|
+      pid = File.read("/tmp/ernie#{i}.pid")
+      `kill -9 #{pid}`
+    end
   end
   
 end

--- a/test/ernie_server_test.rb
+++ b/test/ernie_server_test.rb
@@ -11,22 +11,27 @@ class ErnieServerTest < Test::Unit::TestCase
     context "call" do
       should "handle zeronary" do
         assert_equal :foo, @svc.call.ext.zeronary
+        assert_equal :foo, @svc.call.intTest.zeronary
       end
 
       should "handle unary" do
         assert_equal 5, @svc.call.ext.unary(5)
+        assert_equal 5, @svc.call.intTest.unary(5)
       end
 
       should "handle binary" do
         assert_equal 7, @svc.call.ext.binary(5, 2)
+        assert_equal 7, @svc.call.intTest.binary(5, 2)
       end
 
       should "handle ternary" do
         assert_equal 10, @svc.call.ext.ternary(5, 2, 3)
+        assert_equal 10, @svc.call.intTest.ternary(5, 2, 3)
       end
 
       should "handle massive binaries" do
         assert_equal 8 * 1024 * 1024, @svc.call.ext.big(8 * 1024 * 1024).size
+        assert_equal 8 * 1024 * 1024, @svc.call.intTest.big(8 * 1024 * 1024).size
       end
 
       should "get an error on missing module" do
@@ -66,10 +71,11 @@ class ErnieServerTest < Test::Unit::TestCase
   
   def start_server
     Dir.chdir(ERNIE_ROOT)
-     `#{ERNIE_ROOT}/bin/ernie -c #{ERNIE_ROOT}/test/sample/sample.cfg \
-                              -P /tmp/ernie.pid \
-                              -p #{PORT} \
-                              -d`
+    `erlc #{ERNIE_ROOT}/test/sample/intTest.erl`
+    `#{ERNIE_ROOT}/bin/ernie -c #{ERNIE_ROOT}/test/sample/sample.cfg \
+                            -P /tmp/ernie.pid \
+                            -p #{PORT} \
+                            -d`
     Signal.trap("INT") do
       puts "Shutting Down"
       shutdown_server
@@ -90,6 +96,7 @@ class ErnieServerTest < Test::Unit::TestCase
   def shutdown_server
     pid = File.read('/tmp/ernie.pid')
     `kill -9 #{pid}`
+    `rm intTest.beam`
   end
   
 end

--- a/test/ernie_server_test.rb
+++ b/test/ernie_server_test.rb
@@ -51,6 +51,19 @@ class ErnieServerTest < Test::Unit::TestCase
         assert_equal 8 * 1024 * 1024, svc.call.ext.big(8 * 1024 * 1024).size
         assert_equal 8 * 1024 * 1024, svc.call.intTest.big(8 * 1024 * 1024).size
       end
+      
+      should "not block on internal modules" do
+        time = Time.now
+        svc.call.intTest.sleep(1000)
+        assert(Time.now >= time + 1)
+        
+        time = Time.now
+        svc.cast.intTest.sleep(1000)
+        svc.cast.intTest.sleep(1000)
+        svc.cast.intTest.sleep(1000)
+        svc.call.intTest.zeronary
+        assert(Time.now < time + 1)
+      end
 
       should "get an error on missing module" do
         begin

--- a/test/ernie_server_test.rb
+++ b/test/ernie_server_test.rb
@@ -77,6 +77,12 @@ class ErnieServerTest < Test::Unit::TestCase
         assert_equal nil, svc.cast.ext.set_state(7)
         assert Time.now - t0 < 1
         assert_equal 7, svc.call.ext.get_state
+
+        t0 = Time.now
+        assert_equal nil, svc.cast.intTest.set_state(7)
+        assert Time.now - t0 < 1
+        sleep 0.25
+        assert_equal 7, svc.call.intTest.get_state
       end
     end
 

--- a/test/ernie_server_test.rb
+++ b/test/ernie_server_test.rb
@@ -107,6 +107,9 @@ class ErnieServerTest < Test::Unit::TestCase
   context "Two Ernie Servers" do
     setup do
       start_servers(2)
+      @servers.each do |svc|
+        svc.cast.intTest.connect_nodes
+      end
     end
     
     context "call" do
@@ -146,6 +149,12 @@ class ErnieServerTest < Test::Unit::TestCase
         end
       end
 
+      should "make joined erlang nodes possible" do
+        assert_equal nil, @servers.first.cast.intTest.set_state(7)
+        sleep 0.25
+        assert_equal 7, @servers.last.call.intTest.get_state
+      end
+
     end
 
     teardown do
@@ -172,6 +181,7 @@ class ErnieServerTest < Test::Unit::TestCase
       `#{ERNIE_ROOT}/bin/ernie -c #{ERNIE_ROOT}/test/sample/sample.cfg \
                               -P /tmp/ernie#{@servers.size}.pid \
                               -p #{PORT + @servers.size} \
+                              --name ernie#{@servers.size}@127.0.0.1 \
                               -d`
     
       @servers << BERTRPC::Service.new('localhost', PORT + @servers.size)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'test/unit'
 require 'shoulda'
 
-ERNIE_ROOT = File.join(File.dirname(__FILE__), *%w[..])
+ERNIE_ROOT = File.expand_path(File.join(File.dirname(__FILE__), *%w[..]))
 
 $:.unshift(File.join(ERNIE_ROOT, 'lib'))
 

--- a/test/sample/intTest.erl
+++ b/test/sample/intTest.erl
@@ -1,6 +1,6 @@
 -module(intTest).
 
--export([zeronary/0, unary/1, binary/2, ternary/3, big/1]).
+-export([zeronary/0, unary/1, binary/2, ternary/3, big/1, set_state/1, get_state/0]).
 
 zeronary() ->
 	foo.
@@ -16,3 +16,37 @@ ternary(A,B,C) ->
 	
 big(A) ->
 	string:copies("a", A).
+
+get_state() ->
+	case catch global:send(test_saved_state, {get_state, self()}) of
+		{'EXIT',{badarg, _}} ->
+			{error, no_record};
+		_ ->
+			receive
+				{ok, State} ->
+					State
+				after 1000 ->
+					{error, timeout}
+			end
+	end.
+	
+set_state(State) ->
+	spawn(fun() -> wrapper(State) end),
+	ok.
+
+wrapper(State) ->
+	case global:register_name(test_saved_state, self()) of
+		no ->
+			global:send(test_saved_state, {set_state, State});
+		yes ->
+			recv(State)
+	end.
+
+recv(State) ->
+	receive
+		{set_state, NewState} ->
+			recv(NewState);
+		{get_state, Pid} ->
+			Pid ! {ok, State},
+			recv(State)
+	end.

--- a/test/sample/intTest.erl
+++ b/test/sample/intTest.erl
@@ -1,6 +1,6 @@
 -module(intTest).
 
--export([zeronary/0, unary/1, binary/2, ternary/3, big/1, set_state/1, get_state/0, connect_nodes/0]).
+-export([zeronary/0, unary/1, binary/2, ternary/3, big/1, set_state/1, get_state/0, connect_nodes/0, sleep/1]).
 
 connect_nodes() ->
 	net_adm:ping('ernie0@127.0.0.1').
@@ -19,6 +19,11 @@ ternary(A,B,C) ->
 	
 big(A) ->
 	string:copies("a", A).
+
+sleep(Time) ->
+	receive after Time ->
+		ok
+	end.
 
 get_state() ->
 	case catch global:send(test_saved_state, {get_state, self()}) of

--- a/test/sample/intTest.erl
+++ b/test/sample/intTest.erl
@@ -1,0 +1,18 @@
+-module(intTest).
+
+-export([zeronary/0, unary/1, binary/2, ternary/3, big/1]).
+
+zeronary() ->
+	foo.
+
+unary(A) ->
+	A.
+	
+binary(A,B) ->
+	A + B.
+
+ternary(A,B,C) ->
+	A + B + C.
+	
+big(A) ->
+	string:copies("a", A).

--- a/test/sample/intTest.erl
+++ b/test/sample/intTest.erl
@@ -1,6 +1,9 @@
 -module(intTest).
 
--export([zeronary/0, unary/1, binary/2, ternary/3, big/1, set_state/1, get_state/0]).
+-export([zeronary/0, unary/1, binary/2, ternary/3, big/1, set_state/1, get_state/0, connect_nodes/0]).
+
+connect_nodes() ->
+	net_adm:ping('ernie0@127.0.0.1').
 
 zeronary() ->
 	foo.

--- a/test/sample/sample.cfg
+++ b/test/sample/sample.cfg
@@ -1,4 +1,4 @@
 [{module, ext},
  {type, external},
- {command, "ruby /Users/tom/dev/mojombo/ernie/test/sample/ext.rb"},
+ {command, "ruby test/sample/ext.rb"},
  {count, 1}].

--- a/test/sample/sample.cfg
+++ b/test/sample/sample.cfg
@@ -2,3 +2,7 @@
  {type, external},
  {command, "ruby test/sample/ext.rb"},
  {count, 1}].
+[{module, intTest},
+ {type, native},
+ {codepaths, ["test/sample/intTest"]}
+ ].


### PR DESCRIPTION
Having the ernie server register globally makes is impossible to operate ernie in a connected erlang cluster.  Especially for native handlers it's important to be able to scale this way.  This branch corrects the way ernie registers its services so multiple ernie nodes can operate together in a cluster.  Tests are updated.

I'm going to close issue 10 as this new pull request format will duplicate it (i think).
