### PR TITLE
Fixed server hang when BERT.decode fails

### DIFF
--- a/lib/ernie.rb
+++ b/lib/ernie.rb
@@ -133,7 +133,19 @@ class Ernie
 
     loop do
       self.procline('waiting')
-      iruby = self.read_berp(input)
+
+      begin
+        iruby = self.read_berp(input)
+      rescue => e
+        oruby = t[:error, t[:server, 0, e.class.to_s, e.message, e.backtrace]]
+        if self.log.level <= Logger::ERROR
+          self.log.error("BERT decoder failed.  Returning error.")
+          self.log.error("<- " + oruby.inspect)
+          self.log.error(e.backtrace.join("\n"))
+        end
+        write_berp(output, oruby)
+      end
+
       self.count += 1
 
       unless iruby


### PR DESCRIPTION
When the BERT portion of a BERP fails to decode correctly via `BERT.decode` in a Ruby handler the exception is not caught.  This causes the Ruby handler to exit without notifying the erlang process which continues to wait indefinitely for a response.  A few bad requests and all Ruby handlers are down until Ernie is restarted.

This (tested) patch wraps the decode process in a `begin...end` block rescuing any errors and returning them as expected by the protocol.
