### PR TITLE
Persistent Connections

### DIFF
--- a/elib/ernie.hrl
+++ b/elib/ernie.hrl
@@ -10,7 +10,9 @@
                   log = undefined,      % log information
                   infos = [],           % list of info binaries
                   action = undefined,   % action binary
-                  priority = high}).    % priority [ high | low ]
+                  priority = high,      % priority [ high | low ]
+                  con_pid = undefined   % connection pid
+              }).
 
 -record(log, {taccept = erlang:now(),   % time that connection was accepted
               tprocess = erlang:now(),  % time that processing started

--- a/elib/ernie_native.erl
+++ b/elib/ernie_native.erl
@@ -19,7 +19,7 @@ process(ActionTerm, Request) ->
       Data = term_to_binary({error, [user, 0, <<"RuntimeError">>, BError, BTrace]}),
       gen_tcp:send(Sock, Data)
   end,
-  ok = gen_tcp:close(Sock),
+  Request#request.con_pid ! done,
   ernie_server:fin(),
   Log = Request#request.log,
   Log2 = Log#log{tdone = erlang:now()},

--- a/elib/ernie_server.erl
+++ b/elib/ernie_server.erl
@@ -196,7 +196,7 @@ receive_term(Request, State, RecvTimeout) ->
           ernie_server:kick(),
           receive
             done ->
-                receive_term(Request, State, 10000); %% timeout within 10s
+                receive_term(Request, State, RecvTimeout); %% infinity is probably not the best value
             _ ->
                 ok
           end


### PR DESCRIPTION
### Basic implementation for persistent connections

The request record now contains the pid of the receive_term process <code>#request.con_pid</code> which allows to report back once the processing is done. After the <code>receive_term</code> function kicked the queue it waits for this signal (<code>#request.con_pid ! done</code>) that the request has been executed and calls itself with an extra receive-timeout parameter (e.g. 10 seconds) preventing socket starvation. From here either a new request is received over the same connection or the receive times out which closes the socket.

This is implemented for call/cast in external and native handlers.
